### PR TITLE
add keyword arguments in frule

### DIFF
--- a/src/ForwardDiffChainRules.jl
+++ b/src/ForwardDiffChainRules.jl
@@ -66,7 +66,7 @@ function _fd_frule(sig)
             flat_ypartials1, _ = ForwardDiffChainRules.DifferentiableFlatten.flatten(ypartials1)
             flat_ypartials = hcat(reshape(flat_ypartials1, :, 1), ntuple(Val(CS - 1)) do i
                 xpartialsi = unflattenx(flat_xpartials[:, i+1])
-                _, ypartialsi = ChainRulesCore.frule((NoTangent(), xpartialsi...), f, xprimals...)
+                _, ypartialsi = ChainRulesCore.frule((NoTangent(), xpartialsi...), f, xprimals..., ks...)
                 return ForwardDiffChainRules.DifferentiableFlatten.flatten(ypartialsi)[1]
             end...)
 

--- a/src/ForwardDiffChainRules.jl
+++ b/src/ForwardDiffChainRules.jl
@@ -66,7 +66,7 @@ function _fd_frule(sig)
             flat_ypartials1, _ = ForwardDiffChainRules.DifferentiableFlatten.flatten(ypartials1)
             flat_ypartials = hcat(reshape(flat_ypartials1, :, 1), ntuple(Val(CS - 1)) do i
                 xpartialsi = unflattenx(flat_xpartials[:, i+1])
-                _, ypartialsi = ChainRulesCore.frule((NoTangent(), xpartialsi...), f, xprimals..., ks...)
+                _, ypartialsi = ChainRulesCore.frule((NoTangent(), xpartialsi...), f, xprimals...; ks...)
                 return ForwardDiffChainRules.DifferentiableFlatten.flatten(ypartialsi)[1]
             end...)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -171,7 +171,7 @@ SOFTWARE.
     @testset "kwargs" begin
         fkwarg(x; a = 2.0) = x * a
         frule_count = 0
-        function ChainRulesCore.frule((_, Δx), ::typeof(fkwarg), x::Real; a)
+        function ChainRulesCore.frule((_, Δx), ::typeof(fkwarg), x::Real; a = 2.0)
             global frule_count += 1
             println("frule was called")
             return fkwarg(x; a), a * Δx

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -171,7 +171,7 @@ SOFTWARE.
     @testset "kwargs" begin
         fkwarg(x; a = 2.0) = x * a
         frule_count = 0
-        function ChainRulesCore.frule((_, Δx), ::typeof(fkwarg), x::Real; a = 2.0)
+        function ChainRulesCore.frule((_, Δx), ::typeof(fkwarg), x::Real; a)
             global frule_count += 1
             println("frule was called")
             return fkwarg(x; a), a * Δx


### PR DESCRIPTION
Hi, thank you for the nice work for facilitating the ForwardDiff custom rules and I find this light weight package very practical. In some use cases, it seems to have some issue with passing the keyword arguments into the user-predefined `ChainRuleCore.frule`, thus a tiny fix was done. Could you have a look please? thank you!