### PR TITLE
Define and use ForwardDiffRuleConfig

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -9,7 +9,7 @@ jobs:
       # Don't cancel in-progress jobs if any matrix job fails
       fail-fast: false
       matrix:
-        julia-version: ['1.6', '1'] # "1" automatically expands to the latest stable 1.x release of Julia
+        julia-version: ['1'] # "1" automatically expands to the latest stable 1.x release of Julia
         julia-arch: [x64]
         os: [ubuntu-latest, windows-latest]
         experimental: [false]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,8 +2,10 @@
 ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+ImplicitDifferentiation = "57b37032-215b-411a-8a7c-41a003a55207"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NamedTupleTools = "d9ec5142-1e00-5aa0-9d6a-321866360f50"
+Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,8 @@ using ForwardDiffChainRules
 using Test
 using ChainRules, ChainRulesCore, ForwardDiff
 using LinearAlgebra
+using ImplicitDifferentiation, Optim
+import NamedTupleTools: ntfromstruct, structfromnt
 
 #
 # Copyright (c) 2022 The contributors
@@ -95,7 +97,6 @@ SOFTWARE.
 
         # I recommend creating your own type to avoid piracy
         ForwardDiffChainRules.DifferentiableFlatten.@constructor Symmetric Symmetric
-        import NamedTupleTools: ntfromstruct, structfromnt
         ntfromstruct(a::Symmetric) = (data = a.data,)
         structfromnt(::Type{Symmetric}, x::NamedTuple) = Symmetric(x.data, :U)
         @ForwardDiff_frule _eigvals!(A::Symmetric{<:ForwardDiff.Dual})
@@ -180,4 +181,21 @@ SOFTWARE.
         @test ForwardDiff.gradient(x -> fkwarg(x[1], x[2], a = 3.0), [1.0, 2.0]) == [6, 3]
         @test frule_count == 2
     end
+end
+
+@testset "ImplicitDifferentiation" begin
+    function dumb_identity(x)
+        f(y) = sum(abs2, y-x)
+        y0 = zero(x)
+        res = optimize(f, y0, LBFGS(); autodiff=:forward)
+        y = Optim.minimizer(res)
+        return y
+    end
+    zero_gradient(x, y) = 2(y - x);
+    implicit = ImplicitFunction(dumb_identity, zero_gradient);
+    x = rand(3, 2)
+    J1 = ForwardDiff.jacobian(implicit, x)
+    @ForwardDiff_frule (f::typeof(implicit))(x::AbstractMatrix{<:ForwardDiff.Dual})
+    J2 = ForwardDiff.jacobian(implicit, x)
+    @test J1 ≈ J2
 end


### PR DESCRIPTION
This PR was needed to get ImplicitDifferentiation to use ForwardDiffChainRules. With this PR, this works.
```julia
using ImplicitDifferentiation
using Optim
using Random
using ForwardDiff, ForwardDiffChainRules

Random.seed!(63)
function dumb_identity(x)
    f(y) = sum(abs2, y-x)
    y0 = zero(x)
    res = optimize(f, y0, LBFGS(); autodiff=:forward)
    y = Optim.minimizer(res)
    return y
end;
zero_gradient(x, y) = 2(y - x);
implicit = ImplicitFunction(dumb_identity, zero_gradient);
x = rand(3, 2)
@ForwardDiff_frule (f::typeof(implicit))(x::AbstractMatrix{<:ForwardDiff.Dual})
ForwardDiff.jacobian(implicit, x)
```
