### PR TITLE
remove ImplicitDifferentiation tests

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,10 +2,8 @@
 ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
-ImplicitDifferentiation = "57b37032-215b-411a-8a7c-41a003a55207"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NamedTupleTools = "d9ec5142-1e00-5aa0-9d6a-321866360f50"
-Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,6 @@ using Test
 using ChainRules, ChainRulesCore, ForwardDiff
 using LinearAlgebra
 import NamedTupleTools: ntfromstruct, structfromnt
-using ImplicitDifferentiation, Optim
 
 #
 # Copyright (c) 2022 The contributors
@@ -181,21 +180,4 @@ SOFTWARE.
         @test ForwardDiff.gradient(x -> fkwarg(x[1], x[2], a = 3.0), [1.0, 2.0]) == [6, 3]
         @test frule_count == 2
     end
-end
-
-@testset "ImplicitDifferentiation" begin
-    function dumb_identity(x)
-        f(y) = sum(abs2, y-x)
-        y0 = zero(x)
-        res = optimize(f, y0, LBFGS(); autodiff=:forward)
-        y = Optim.minimizer(res)
-        return y
-    end
-    zero_gradient(x, y) = 2(y - x);
-    implicit = ImplicitFunction(dumb_identity, zero_gradient);
-    x = rand(3, 2)
-    J1 = ForwardDiff.jacobian(implicit, x)
-    @ForwardDiff_frule (f::typeof(implicit))(x::AbstractMatrix{<:ForwardDiff.Dual})
-    J2 = ForwardDiff.jacobian(implicit, x)
-    @test J1 ≈ J2
 end


### PR DESCRIPTION
ImplicitDifferentiation 0.4 now by default defines a method for dual numbers and doesn't require ForwardDiffChainRules.